### PR TITLE
fix: ensure some slides are not visible on print (meanwhile we remove them, reveal add them elsewhere...)

### DIFF
--- a/src/addons/tc-multiples-cols.ts
+++ b/src/addons/tc-multiples-cols.ts
@@ -65,6 +65,7 @@ export function postManageMultiplesColumns() {
     }
 
     for (const colSection of allColsSection) {
+        colSection.setAttribute('data-slide-to-remove', 'true');
         colSection.remove(); // We remove the section in order to avoid strange behaviour with fragment or verticals slides
     }
 }

--- a/src/scss/theme/print.scss
+++ b/src/scss/theme/print.scss
@@ -3,6 +3,12 @@
 */
 html.print-pdf {
     .reveal .slides .pdf-page {
+        &:has([data-slide-to-remove]) {
+            // hack to ensure some slides were not visible
+            // - some extras slides added when using multiples cols meanwhile we removed it 🙈
+            display: none !important;
+        }
+
         div.slide-background.quote-slide::before {
             content: '';
             position: absolute;


### PR DESCRIPTION
As I analyzed:
- multiple cols feature create some slide duplication, but some with no content
- the actual behavior is to remove those slides but it does not remove everything (we remove every slide we can get, but some slides seems to be added at another timing)
- I did not understand for now why there is those extra slides, but adding an attribute works so...
- I added a css hack to hide every slide with attribute `data-slide-to-remove` and it "works"