### PR TITLE
chore: add multi-tool AI agent configuration

### DIFF
--- a/.agents/hooks.json
+++ b/.agents/hooks.json
@@ -1,0 +1,16 @@
+{
+    "lint-on-edit": {
+        "PostToolUse": [
+            {
+                "matcher": "write_to_file|replace_file_content|multi_replace_file_content",
+                "hooks": [
+                    {
+                        "type": "command",
+                        "command": "npm run lint:fix && npm run prettier:fix",
+                        "timeout": 60
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/.agents/hooks.json
+++ b/.agents/hooks.json
@@ -6,7 +6,7 @@
                 "hooks": [
                     {
                         "type": "command",
-                        "command": "npm run lint:fix && npm run prettier:fix",
+                        "command": "jq -r '.tool_input.file_path // .tool_input.TargetFile // \"\"' | { read -r f; ./.hooks/post-file-change.sh \"$f\"; } || true",
                         "timeout": 60
                     }
                 ]

--- a/.agents/skills/addon-scaffold/SKILL.md
+++ b/.agents/skills/addon-scaffold/SKILL.md
@@ -1,0 +1,142 @@
+---
+name: addon-scaffold
+description: >
+  Generate a new addon for TalkControl following TypeScript + Vitest conventions.
+  Use when the user says "create an addon", "new addon", "add an addon", or wants to generate
+  src/addons/tc-{name}.ts and corresponding Vitest spec.
+  Follow existing patterns: TcXxxOptions interface, manage/apply function, conditional _internals export,
+  and Vitest spec with describe/it/beforeEach.
+---
+
+# Addon Scaffold — Addon Generator
+
+## Purpose
+
+Guide the user to create a new addon in two files:
+- `src/addons/tc-{name}.ts` — implementation
+- `src/addons/tc-{name}.spec.ts` — Vitest tests
+
+Enforce consistency by following established project patterns.
+
+## Conversational Workflow
+
+### 1. Request Addon Name
+
+**Ask**: "What is the addon name? (e.g., clipboard-history, syntax-highlight)"
+
+Automatically derive from the provided name:
+- **PascalCase** for the type (e.g., "clipboard-history" → `ClipboardHistory`)
+- **camelCase** for the function (e.g., `manageClipboardHistory`)
+- **kebab-case** for files (e.g., `tc-clipboard-history.ts`)
+
+### 2. Request Addon Details
+
+**Ask**:
+- "Brief description of what this addon does?"
+- "Will the function be manage[Name] or apply[Name]?" (default: manage)
+- "Additional options beyond `active?: boolean`?" (If yes, list field names)
+- "Any dependencies or mocks needed?" (e.g., import from '../utils/helper')
+
+### 3. Generate TypeScript File
+
+Create `src/addons/tc-{name}.ts` following this pattern:
+
+```typescript
+// Imports (adapt based on actual dependencies)
+export interface Tc{PascalName}Options {
+    active?: boolean;
+    // + additional fields if applicable
+}
+
+/**
+ * {Brief description from user}
+ * @param options configuration options
+ * @returns void
+ */
+export function {manage|apply}{PascalName}(options: Tc{PascalName}Options): void {
+    if (!options.active) {
+        return;
+    }
+
+    // TODO: Implement logic
+}
+
+// Private helper functions (optional)
+// function _helperName(...) { ... }
+
+// Export _internals (required pattern)
+export const _internals =
+    typeof process !== 'undefined' && process?.env?.NODE_ENV === 'test'
+        ? {
+              // Export testable helper functions here if applicable
+              // _helperName,
+          }
+        : undefined;
+```
+
+### 4. Generate Spec File
+
+Create `src/addons/tc-{name}.spec.ts` following this pattern:
+
+```typescript
+/**
+ * @vitest-environment jsdom
+ */
+import { {manage|apply}{PascalName}, Tc{PascalName}Options } from './tc-{kebab-name}';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const HTML = `
+<div class="reveal">
+    <div class="slides">
+        <!-- DOM fixture for tests -->
+    </div>
+</div>
+`;
+
+// vi.mock('../utils/helper', () => ({...})); // if needed
+
+describe('{PascalName}', () => {
+    beforeEach(() => {
+        document.body.innerHTML = HTML;
+    });
+
+    it('should export the function', () => {
+        expect({manage|apply}{PascalName}).toBeDefined();
+    });
+
+    it('should not do anything if options.active is false', () => {
+        const options: Tc{PascalName}Options = { active: false };
+        const result = {manage|apply}{PascalName}(options);
+        expect(result).toBeUndefined();
+    });
+
+    it('should work when options.active is true', () => {
+        const options: Tc{PascalName}Options = { active: true };
+        // TODO: Add meaningful test for actual logic
+        const result = {manage|apply}{PascalName}(options);
+        expect(result).toBeUndefined();
+    });
+});
+```
+
+## Conventions (Mandatory)
+
+- **Interface**: Always named `Tc{PascalName}Options`, ALWAYS includes `active?: boolean` as first field
+- **Function**: Starts with `manage` or `apply` followed by PascalCase name
+- **Helper functions**: Prefix with `_`, accessible only via `_internals` in test mode
+- **_internals**: Conditional export returning helpers in test, `undefined` otherwise
+- **Spec file**: Must include `@vitest-environment jsdom` directive, use `describe/it/beforeEach` structure
+- **No over-abstraction**: Each addon is unique; don't force shared patterns prematurely
+
+## Final Output
+
+Display:
+```
+✅ Created src/addons/tc-{kebab-name}.ts
+✅ Created src/addons/tc-{kebab-name}.spec.ts
+
+Next steps:
+  1. Implement logic in the .ts file
+  2. Add meaningful tests in the .spec.ts file
+  3. Run tests: npm run test -- {kebab-name}
+```

--- a/.agents/skills/addon-scaffold/SKILL.md
+++ b/.agents/skills/addon-scaffold/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: addon-scaffold
 description: >
-  Generate a new addon for TalkControl following TypeScript + Vitest conventions.
-  Use when the user says "create an addon", "new addon", "add an addon", or wants to generate
-  src/addons/tc-{name}.ts and corresponding Vitest spec.
-  Follow existing patterns: TcXxxOptions interface, manage/apply function, conditional _internals export,
-  and Vitest spec with describe/it/beforeEach.
+    Generate a new addon for TalkControl following TypeScript + Vitest conventions.
+    Use when the user says "create an addon", "new addon", "add an addon", or wants to generate
+    src/addons/tc-{name}.ts and corresponding Vitest spec.
+    Follow existing patterns: TcXxxOptions interface, manage/apply function, conditional _internals export,
+    and Vitest spec with describe/it/beforeEach.
 ---
 
 # Addon Scaffold — Addon Generator
@@ -13,8 +13,9 @@ description: >
 ## Purpose
 
 Guide the user to create a new addon in two files:
-- `src/addons/tc-{name}.ts` — implementation
-- `src/addons/tc-{name}.spec.ts` — Vitest tests
+
+-   `src/addons/tc-{name}.ts` — implementation
+-   `src/addons/tc-{name}.spec.ts` — Vitest tests
 
 Enforce consistency by following established project patterns.
 
@@ -25,17 +26,19 @@ Enforce consistency by following established project patterns.
 **Ask**: "What is the addon name? (e.g., clipboard-history, syntax-highlight)"
 
 Automatically derive from the provided name:
-- **PascalCase** for the type (e.g., "clipboard-history" → `ClipboardHistory`)
-- **camelCase** for the function (e.g., `manageClipboardHistory`)
-- **kebab-case** for files (e.g., `tc-clipboard-history.ts`)
+
+-   **PascalCase** for the type (e.g., "clipboard-history" → `ClipboardHistory`)
+-   **camelCase** for the function (e.g., `manageClipboardHistory`)
+-   **kebab-case** for files (e.g., `tc-clipboard-history.ts`)
 
 ### 2. Request Addon Details
 
 **Ask**:
-- "Brief description of what this addon does?"
-- "Will the function be manage[Name] or apply[Name]?" (default: manage)
-- "Additional options beyond `active?: boolean`?" (If yes, list field names)
-- "Any dependencies or mocks needed?" (e.g., import from '../utils/helper')
+
+-   "Brief description of what this addon does?"
+-   "Will the function be manage[Name] or apply[Name]?" (default: manage)
+-   "Additional options beyond `active?: boolean`?" (If yes, list field names)
+-   "Any dependencies or mocks needed?" (e.g., import from '../utils/helper')
 
 ### 3. Generate TypeScript File
 
@@ -121,16 +124,17 @@ describe('{PascalName}', () => {
 
 ## Conventions (Mandatory)
 
-- **Interface**: Always named `Tc{PascalName}Options`, ALWAYS includes `active?: boolean` as first field
-- **Function**: Starts with `manage` or `apply` followed by PascalCase name
-- **Helper functions**: Prefix with `_`, accessible only via `_internals` in test mode
-- **_internals**: Conditional export returning helpers in test, `undefined` otherwise
-- **Spec file**: Must include `@vitest-environment jsdom` directive, use `describe/it/beforeEach` structure
-- **No over-abstraction**: Each addon is unique; don't force shared patterns prematurely
+-   **Interface**: Always named `Tc{PascalName}Options`, ALWAYS includes `active?: boolean` as first field
+-   **Function**: Starts with `manage` or `apply` followed by PascalCase name
+-   **Helper functions**: Prefix with `_`, accessible only via `_internals` in test mode
+-   **\_internals**: Conditional export returning helpers in test, `undefined` otherwise
+-   **Spec file**: Must include `@vitest-environment jsdom` directive, use `describe/it/beforeEach` structure
+-   **No over-abstraction**: Each addon is unique; don't force shared patterns prematurely
 
 ## Final Output
 
 Display:
+
 ```
 ✅ Created src/addons/tc-{kebab-name}.ts
 ✅ Created src/addons/tc-{kebab-name}.spec.ts

--- a/.agents/skills/release/SKILL.md
+++ b/.agents/skills/release/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: release
+description: >
+  Publish a new version of the npm package @talk-control/talk-control-revealjs-extensions.
+  Use when the user mentions "release", "publish", "npm publish", "new version", "bump version", or "tag".
+  Guides step by step: working tree check, bump type choice, build, tests, version bump, commit, tag, push, publish.
+---
+
+# Release — npm Publication
+
+## Overview
+
+The release workflow is automated via `npm run release` (calls `scripts/release.ts`).
+
+**Order of operations — build and tests run BEFORE bumping the version:**
+1. Check clean working tree
+2. Ask bump type (patch / minor / major)
+3. Build — stops here if it fails (package.json unchanged)
+4. Tests — stops here if they fail (package.json unchanged)
+5. Bump version in package.json
+6. git commit + git tag vX.Y.Z
+7. git push + git push --tags
+8. npm publish
+
+## Running the Release
+
+```bash
+npm run release
+```
+
+The script is interactive — it will ask for the bump type and show progress for each step.
+
+## Manual Step-by-Step (if the script fails mid-way)
+
+### 1. Check clean working tree
+```bash
+git status --porcelain
+```
+If output is non-empty, commit or stash changes first.
+
+### 2. Build
+```bash
+npm run build
+```
+
+### 3. Tests
+```bash
+npx vitest run
+```
+Note: use `npx vitest run` (single pass), NOT `npm run test` (watch mode).
+
+### 4. Bump version
+```bash
+npm version patch --no-git-tag-version
+# or: minor / major
+```
+`--no-git-tag-version` prevents npm from creating the git tag automatically.
+
+### 5. Commit + Tag
+```bash
+git add package.json package-lock.json
+git commit -m "chore: bump version to vX.Y.Z"
+git tag vX.Y.Z
+```
+
+### 6. Push
+```bash
+git push
+git push --tags
+```
+
+### 7. Publish
+```bash
+npm publish
+```
+`publishConfig.access: "public"` is already set in package.json — no `--access public` needed.
+
+## If a Step Fails After the Commit
+
+- Do NOT delete the git tag automatically
+- `npm publish` can be re-run independently if push succeeded but publish failed
+- Report what failed and suggest the exact command to resume

--- a/.agents/skills/release/SKILL.md
+++ b/.agents/skills/release/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: release
 description: >
-  Publish a new version of the npm package @talk-control/talk-control-revealjs-extensions.
-  Use when the user mentions "release", "publish", "npm publish", "new version", "bump version", or "tag".
-  Guides step by step: working tree check, bump type choice, build, tests, version bump, commit, tag, push, publish.
+    Publish a new version of the npm package @talk-control/talk-control-revealjs-extensions.
+    Use when the user mentions "release", "publish", "npm publish", "new version", "bump version", or "tag".
+    Guides step by step: working tree check, bump type choice, build, tests, version bump, commit, tag, push, publish.
 ---
 
 # Release — npm Publication
@@ -13,6 +13,7 @@ description: >
 The release workflow is automated via `npm run release` (calls `scripts/release.ts`).
 
 **Order of operations — build and tests run BEFORE bumping the version:**
+
 1. Check clean working tree
 2. Ask bump type (patch / minor / major)
 3. Build — stops here if it fails (package.json unchanged)
@@ -33,30 +34,38 @@ The script is interactive — it will ask for the bump type and show progress fo
 ## Manual Step-by-Step (if the script fails mid-way)
 
 ### 1. Check clean working tree
+
 ```bash
 git status --porcelain
 ```
+
 If output is non-empty, commit or stash changes first.
 
 ### 2. Build
+
 ```bash
 npm run build
 ```
 
 ### 3. Tests
+
 ```bash
 npx vitest run
 ```
+
 Note: use `npx vitest run` (single pass), NOT `npm run test` (watch mode).
 
 ### 4. Bump version
+
 ```bash
 npm version patch --no-git-tag-version
 # or: minor / major
 ```
+
 `--no-git-tag-version` prevents npm from creating the git tag automatically.
 
 ### 5. Commit + Tag
+
 ```bash
 git add package.json package-lock.json
 git commit -m "chore: bump version to vX.Y.Z"
@@ -64,19 +73,22 @@ git tag vX.Y.Z
 ```
 
 ### 6. Push
+
 ```bash
 git push
 git push --tags
 ```
 
 ### 7. Publish
+
 ```bash
 npm publish
 ```
+
 `publishConfig.access: "public"` is already set in package.json — no `--access public` needed.
 
 ## If a Step Fails After the Commit
 
-- Do NOT delete the git tag automatically
-- `npm publish` can be re-run independently if push succeeded but publish failed
-- Report what failed and suggest the exact command to resume
+-   Do NOT delete the git tag automatically
+-   `npm publish` can be re-run independently if push succeeded but publish failed
+-   Report what failed and suggest the exact command to resume

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,17 @@
+{
+    "hooks": {
+        "PostToolUse": [
+            {
+                "matcher": "Write|Edit",
+                "hooks": [
+                    {
+                        "type": "command",
+                        "command": "jq -r '.tool_input.file_path // \"\"' | { read -r f; [[ \"$f\" =~ /src/.*\\.(ts|scss)$ ]] && npm run lint:fix && npm run prettier:fix; } 2>/dev/null || true",
+                        "timeout": 60,
+                        "statusMessage": "Linting & formatting src/..."
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,9 +6,9 @@
                 "hooks": [
                     {
                         "type": "command",
-                        "command": "jq -r '.tool_input.file_path // \"\"' | { read -r f; [[ \"$f\" =~ /src/.*\\.(ts|scss)$ ]] && npm run lint:fix && npm run prettier:fix; } 2>/dev/null || true",
+                        "command": "jq -r '.tool_input.file_path // \"\"' | { read -r f; \"${CLAUDE_PROJECT_DIR:-.}/.hooks/post-file-change.sh\" \"$f\"; } || true",
                         "timeout": 60,
-                        "statusMessage": "Linting & formatting src/..."
+                        "statusMessage": "Formatting changed file..."
                     }
                 ]
             }

--- a/.claude/skills/addon-scaffold/SKILL.md
+++ b/.claude/skills/addon-scaffold/SKILL.md
@@ -1,20 +1,23 @@
 ---
 name: addon-scaffold
 description: >
-  Generate a new addon for TalkControl following TypeScript + Vitest conventions.
-  Use when the user says "create an addon", "new addon", "add an addon", or wants to generate
-  src/addons/tc-{name}.ts and corresponding Vitest spec.
-  Follow existing patterns: TcXxxOptions interface, manage/apply function, conditional _internals export,
-  and Vitest spec with describe/it/beforeEach.
+    Generate a new addon for TalkControl following TypeScript + Vitest conventions.
+    Use when the user says "create an addon", "new addon", "add an addon", or wants to generate
+    src/addons/tc-{name}.ts and corresponding Vitest spec.
+    Follow existing patterns: TcXxxOptions interface, manage/apply function, conditional _internals export,
+    and Vitest spec with describe/it/beforeEach.
 ---
+
+<!-- AUTO-GENERATED from .agents/skills/addon-scaffold/SKILL.md — do not edit. Edit the source, then run: npm run agents:sync -->
 
 # Addon Scaffold — Addon Generator
 
 ## Purpose
 
 Guide the user to create a new addon in two files:
-- `src/addons/tc-{name}.ts` — implementation
-- `src/addons/tc-{name}.spec.ts` — Vitest tests
+
+-   `src/addons/tc-{name}.ts` — implementation
+-   `src/addons/tc-{name}.spec.ts` — Vitest tests
 
 Enforce consistency by following established project patterns.
 
@@ -25,17 +28,19 @@ Enforce consistency by following established project patterns.
 **Ask**: "What is the addon name? (e.g., clipboard-history, syntax-highlight)"
 
 Automatically derive from the provided name:
-- **PascalCase** for the type (e.g., "clipboard-history" → `ClipboardHistory`)
-- **camelCase** for the function (e.g., `manageClipboardHistory`)
-- **kebab-case** for files (e.g., `tc-clipboard-history.ts`)
+
+-   **PascalCase** for the type (e.g., "clipboard-history" → `ClipboardHistory`)
+-   **camelCase** for the function (e.g., `manageClipboardHistory`)
+-   **kebab-case** for files (e.g., `tc-clipboard-history.ts`)
 
 ### 2. Request Addon Details
 
 **Ask**:
-- "Brief description of what this addon does?"
-- "Will the function be manage[Name] or apply[Name]?" (default: manage)
-- "Additional options beyond `active?: boolean`?" (If yes, list field names)
-- "Any dependencies or mocks needed?" (e.g., import from '../utils/helper')
+
+-   "Brief description of what this addon does?"
+-   "Will the function be manage[Name] or apply[Name]?" (default: manage)
+-   "Additional options beyond `active?: boolean`?" (If yes, list field names)
+-   "Any dependencies or mocks needed?" (e.g., import from '../utils/helper')
 
 ### 3. Generate TypeScript File
 
@@ -121,16 +126,17 @@ describe('{PascalName}', () => {
 
 ## Conventions (Mandatory)
 
-- **Interface**: Always named `Tc{PascalName}Options`, ALWAYS includes `active?: boolean` as first field
-- **Function**: Starts with `manage` or `apply` followed by PascalCase name
-- **Helper functions**: Prefix with `_`, accessible only via `_internals` in test mode
-- **_internals**: Conditional export returning helpers in test, `undefined` otherwise
-- **Spec file**: Must include `@vitest-environment jsdom` directive, use `describe/it/beforeEach` structure
-- **No over-abstraction**: Each addon is unique; don't force shared patterns prematurely
+-   **Interface**: Always named `Tc{PascalName}Options`, ALWAYS includes `active?: boolean` as first field
+-   **Function**: Starts with `manage` or `apply` followed by PascalCase name
+-   **Helper functions**: Prefix with `_`, accessible only via `_internals` in test mode
+-   **\_internals**: Conditional export returning helpers in test, `undefined` otherwise
+-   **Spec file**: Must include `@vitest-environment jsdom` directive, use `describe/it/beforeEach` structure
+-   **No over-abstraction**: Each addon is unique; don't force shared patterns prematurely
 
 ## Final Output
 
 Display:
+
 ```
 ✅ Created src/addons/tc-{kebab-name}.ts
 ✅ Created src/addons/tc-{kebab-name}.spec.ts

--- a/.claude/skills/addon-scaffold/SKILL.md
+++ b/.claude/skills/addon-scaffold/SKILL.md
@@ -1,0 +1,142 @@
+---
+name: addon-scaffold
+description: >
+  Generate a new addon for TalkControl following TypeScript + Vitest conventions.
+  Use when the user says "create an addon", "new addon", "add an addon", or wants to generate
+  src/addons/tc-{name}.ts and corresponding Vitest spec.
+  Follow existing patterns: TcXxxOptions interface, manage/apply function, conditional _internals export,
+  and Vitest spec with describe/it/beforeEach.
+---
+
+# Addon Scaffold — Addon Generator
+
+## Purpose
+
+Guide the user to create a new addon in two files:
+- `src/addons/tc-{name}.ts` — implementation
+- `src/addons/tc-{name}.spec.ts` — Vitest tests
+
+Enforce consistency by following established project patterns.
+
+## Conversational Workflow
+
+### 1. Request Addon Name
+
+**Ask**: "What is the addon name? (e.g., clipboard-history, syntax-highlight)"
+
+Automatically derive from the provided name:
+- **PascalCase** for the type (e.g., "clipboard-history" → `ClipboardHistory`)
+- **camelCase** for the function (e.g., `manageClipboardHistory`)
+- **kebab-case** for files (e.g., `tc-clipboard-history.ts`)
+
+### 2. Request Addon Details
+
+**Ask**:
+- "Brief description of what this addon does?"
+- "Will the function be manage[Name] or apply[Name]?" (default: manage)
+- "Additional options beyond `active?: boolean`?" (If yes, list field names)
+- "Any dependencies or mocks needed?" (e.g., import from '../utils/helper')
+
+### 3. Generate TypeScript File
+
+Create `src/addons/tc-{name}.ts` following this pattern:
+
+```typescript
+// Imports (adapt based on actual dependencies)
+export interface Tc{PascalName}Options {
+    active?: boolean;
+    // + additional fields if applicable
+}
+
+/**
+ * {Brief description from user}
+ * @param options configuration options
+ * @returns void
+ */
+export function {manage|apply}{PascalName}(options: Tc{PascalName}Options): void {
+    if (!options.active) {
+        return;
+    }
+
+    // TODO: Implement logic
+}
+
+// Private helper functions (optional)
+// function _helperName(...) { ... }
+
+// Export _internals (required pattern)
+export const _internals =
+    typeof process !== 'undefined' && process?.env?.NODE_ENV === 'test'
+        ? {
+              // Export testable helper functions here if applicable
+              // _helperName,
+          }
+        : undefined;
+```
+
+### 4. Generate Spec File
+
+Create `src/addons/tc-{name}.spec.ts` following this pattern:
+
+```typescript
+/**
+ * @vitest-environment jsdom
+ */
+import { {manage|apply}{PascalName}, Tc{PascalName}Options } from './tc-{kebab-name}';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const HTML = `
+<div class="reveal">
+    <div class="slides">
+        <!-- DOM fixture for tests -->
+    </div>
+</div>
+`;
+
+// vi.mock('../utils/helper', () => ({...})); // if needed
+
+describe('{PascalName}', () => {
+    beforeEach(() => {
+        document.body.innerHTML = HTML;
+    });
+
+    it('should export the function', () => {
+        expect({manage|apply}{PascalName}).toBeDefined();
+    });
+
+    it('should not do anything if options.active is false', () => {
+        const options: Tc{PascalName}Options = { active: false };
+        const result = {manage|apply}{PascalName}(options);
+        expect(result).toBeUndefined();
+    });
+
+    it('should work when options.active is true', () => {
+        const options: Tc{PascalName}Options = { active: true };
+        // TODO: Add meaningful test for actual logic
+        const result = {manage|apply}{PascalName}(options);
+        expect(result).toBeUndefined();
+    });
+});
+```
+
+## Conventions (Mandatory)
+
+- **Interface**: Always named `Tc{PascalName}Options`, ALWAYS includes `active?: boolean` as first field
+- **Function**: Starts with `manage` or `apply` followed by PascalCase name
+- **Helper functions**: Prefix with `_`, accessible only via `_internals` in test mode
+- **_internals**: Conditional export returning helpers in test, `undefined` otherwise
+- **Spec file**: Must include `@vitest-environment jsdom` directive, use `describe/it/beforeEach` structure
+- **No over-abstraction**: Each addon is unique; don't force shared patterns prematurely
+
+## Final Output
+
+Display:
+```
+✅ Created src/addons/tc-{kebab-name}.ts
+✅ Created src/addons/tc-{kebab-name}.spec.ts
+
+Next steps:
+  1. Implement logic in the .ts file
+  2. Add meaningful tests in the .spec.ts file
+  3. Run tests: npm run test -- {kebab-name}
+```

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,85 +1,96 @@
 ---
 name: release
 description: >
-  Publie une nouvelle version du package npm @talk-control/talk-control-revealjs-extensions.
-  Utilise ce skill dès que l'utilisateur mentionne "release", "publier", "publish", "npm publish",
-  "nouvelle version", "bump version", "tag", ou veut livrer une version sur npm.
-  Le skill guide pas à pas : vérification du working tree, choix du bump, build, tests, commit, tag, push, publish.
+    Publish a new version of the npm package @talk-control/talk-control-revealjs-extensions.
+    Use when the user mentions "release", "publish", "npm publish", "new version", "bump version", or "tag".
+    Guides step by step: working tree check, bump type choice, build, tests, version bump, commit, tag, push, publish.
 ---
 
-# Release — Publication npm
+<!-- AUTO-GENERATED from .agents/skills/release/SKILL.md — do not edit. Edit the source, then run: npm run agents:sync -->
 
-## Étapes
+# Release — npm Publication
 
-### 1. Vérifier que le working tree est propre
+## Overview
+
+The release workflow is automated via `npm run release` (calls `scripts/release.ts`).
+
+**Order of operations — build and tests run BEFORE bumping the version:**
+
+1. Check clean working tree
+2. Ask bump type (patch / minor / major)
+3. Build — stops here if it fails (package.json unchanged)
+4. Tests — stops here if they fail (package.json unchanged)
+5. Bump version in package.json
+6. git commit + git tag vX.Y.Z
+7. git push + git push --tags
+8. npm publish
+
+## Running the Release
+
+```bash
+npm run release
+```
+
+The script is interactive — it will ask for the bump type and show progress for each step.
+
+## Manual Step-by-Step (if the script fails mid-way)
+
+### 1. Check clean working tree
 
 ```bash
 git status --porcelain
 ```
 
-Si la sortie est non vide, **arrête-toi** et demande à l'utilisateur de commiter ou stasher ses changements avant de continuer. Ne pas procéder avec un working tree sale.
+If output is non-empty, commit or stash changes first.
 
-### 2. Demander le type de bump
-
-Utilise `AskUserQuestion` pour demander le type de bump :
-- **patch** — correction de bug, rétrocompatible (ex: 1.0.0-rc-5 → 1.0.0-rc-6)
-- **minor** — nouvelle fonctionnalité rétrocompatible
-- **major** — breaking change
-
-Affiche aussi la version actuelle lue dans `package.json` pour que l'utilisateur sache d'où on part.
-
-### 3. Calculer et appliquer la nouvelle version
-
-Lis la version dans `package.json`, calcule la nouvelle version selon le bump choisi, puis mets à jour `package.json` avec `npm version <patch|minor|major> --no-git-tag-version`.
-
-L'option `--no-git-tag-version` évite que npm crée lui-même le tag git — on le fait manuellement à l'étape 6 pour garder le contrôle.
-
-### 4. Build
+### 2. Build
 
 ```bash
 npm run build
 ```
 
-Si le build échoue, **arrête-toi** et reporte l'erreur à l'utilisateur. Reverts la version dans `package.json` si nécessaire.
-
-### 5. Tests
+### 3. Tests
 
 ```bash
 npx vitest run
 ```
 
-> Note : `npm run test` lance vitest en mode watch (interactif). Utilise `npx vitest run` pour une passe unique non-interactive.
+Note: use `npx vitest run` (single pass), NOT `npm run test` (watch mode).
 
-Si les tests échouent, **arrête-toi** et reporte l'erreur. Reverts la version dans `package.json`.
-
-### 6. Commit + tag
+### 4. Bump version
 
 ```bash
-git add package.json
+npm version patch --no-git-tag-version
+# or: minor / major
+```
+
+`--no-git-tag-version` prevents npm from creating the git tag automatically.
+
+### 5. Commit + Tag
+
+```bash
+git add package.json package-lock.json
 git commit -m "chore: bump version to vX.Y.Z"
 git tag vX.Y.Z
 ```
 
-Remplace `X.Y.Z` par la nouvelle version calculée à l'étape 3.
-
-### 7. Push
+### 6. Push
 
 ```bash
 git push
 git push --tags
 ```
 
-### 8. Publish
+### 7. Publish
 
 ```bash
 npm publish
 ```
 
-`publishConfig.access: "public"` est déjà défini dans `package.json`, pas besoin de `--access public`.
+`publishConfig.access: "public"` is already set in package.json — no `--access public` needed.
 
-## En cas d'erreur
+## If a Step Fails After the Commit
 
-Si une étape échoue après le commit git (étapes 7 ou 8) :
-- Ne pas supprimer le tag git automatiquement
-- Expliquer à l'utilisateur ce qui a échoué et proposer la commande manuelle pour reprendre
-- Pour un échec de publish : `npm publish` peut être relancé sans refaire le commit/tag
+-   Do NOT delete the git tag automatically
+-   `npm publish` can be re-run independently if push succeeded but publish failed
+-   Report what failed and suggest the exact command to resume

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: release
+description: >
+  Publie une nouvelle version du package npm @talk-control/talk-control-revealjs-extensions.
+  Utilise ce skill dès que l'utilisateur mentionne "release", "publier", "publish", "npm publish",
+  "nouvelle version", "bump version", "tag", ou veut livrer une version sur npm.
+  Le skill guide pas à pas : vérification du working tree, choix du bump, build, tests, commit, tag, push, publish.
+---
+
+# Release — Publication npm
+
+## Étapes
+
+### 1. Vérifier que le working tree est propre
+
+```bash
+git status --porcelain
+```
+
+Si la sortie est non vide, **arrête-toi** et demande à l'utilisateur de commiter ou stasher ses changements avant de continuer. Ne pas procéder avec un working tree sale.
+
+### 2. Demander le type de bump
+
+Utilise `AskUserQuestion` pour demander le type de bump :
+- **patch** — correction de bug, rétrocompatible (ex: 1.0.0-rc-5 → 1.0.0-rc-6)
+- **minor** — nouvelle fonctionnalité rétrocompatible
+- **major** — breaking change
+
+Affiche aussi la version actuelle lue dans `package.json` pour que l'utilisateur sache d'où on part.
+
+### 3. Calculer et appliquer la nouvelle version
+
+Lis la version dans `package.json`, calcule la nouvelle version selon le bump choisi, puis mets à jour `package.json` avec `npm version <patch|minor|major> --no-git-tag-version`.
+
+L'option `--no-git-tag-version` évite que npm crée lui-même le tag git — on le fait manuellement à l'étape 6 pour garder le contrôle.
+
+### 4. Build
+
+```bash
+npm run build
+```
+
+Si le build échoue, **arrête-toi** et reporte l'erreur à l'utilisateur. Reverts la version dans `package.json` si nécessaire.
+
+### 5. Tests
+
+```bash
+npx vitest run
+```
+
+> Note : `npm run test` lance vitest en mode watch (interactif). Utilise `npx vitest run` pour une passe unique non-interactive.
+
+Si les tests échouent, **arrête-toi** et reporte l'erreur. Reverts la version dans `package.json`.
+
+### 6. Commit + tag
+
+```bash
+git add package.json
+git commit -m "chore: bump version to vX.Y.Z"
+git tag vX.Y.Z
+```
+
+Remplace `X.Y.Z` par la nouvelle version calculée à l'étape 3.
+
+### 7. Push
+
+```bash
+git push
+git push --tags
+```
+
+### 8. Publish
+
+```bash
+npm publish
+```
+
+`publishConfig.access: "public"` est déjà défini dans `package.json`, pas besoin de `--access public`.
+
+## En cas d'erreur
+
+Si une étape échoue après le commit git (étapes 7 ou 8) :
+- Ne pas supprimer le tag git automatiquement
+- Expliquer à l'utilisateur ce qui a échoué et proposer la commande manuelle pour reprendre
+- Pour un échec de publish : `npm publish` peut être relancé sans refaire le commit/tag

--- a/.gemini/settings.json
+++ b/.gemini/settings.json
@@ -6,7 +6,7 @@
                 "hooks": [
                     {
                         "type": "command",
-                        "command": "FILE=$(echo $GEMINI_TOOL_INPUT | jq -r '.file_path // \"\"'); [[ \"$FILE\" =~ /src/.*\\.(ts|scss)$ ]] && npm run lint:fix && npm run prettier:fix || true",
+                        "command": "FILE=$(echo $GEMINI_TOOL_INPUT | jq -r '.file_path // \"\"'); ./.hooks/post-file-change.sh \"$FILE\" || true",
                         "timeout": 60
                     }
                 ]

--- a/.gemini/settings.json
+++ b/.gemini/settings.json
@@ -1,0 +1,16 @@
+{
+    "hooks": {
+        "AfterTool": [
+            {
+                "matcher": "write_file|replace",
+                "hooks": [
+                    {
+                        "type": "command",
+                        "command": "FILE=$(echo $GEMINI_TOOL_INPUT | jq -r '.file_path // \"\"'); [[ \"$FILE\" =~ /src/.*\\.(ts|scss)$ ]] && npm run lint:fix && npm run prettier:fix || true",
+                        "timeout": 60
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/.gemini/skills/addon-scaffold/SKILL.md
+++ b/.gemini/skills/addon-scaffold/SKILL.md
@@ -1,20 +1,23 @@
 ---
 name: addon-scaffold
 description: >
-  Generate a new addon for TalkControl following TypeScript + Vitest conventions.
-  Use when the user says "create an addon", "new addon", "add an addon", or wants to generate
-  src/addons/tc-{name}.ts and corresponding Vitest spec.
-  Follow existing patterns: TcXxxOptions interface, manage/apply function, conditional _internals export,
-  and Vitest spec with describe/it/beforeEach.
+    Generate a new addon for TalkControl following TypeScript + Vitest conventions.
+    Use when the user says "create an addon", "new addon", "add an addon", or wants to generate
+    src/addons/tc-{name}.ts and corresponding Vitest spec.
+    Follow existing patterns: TcXxxOptions interface, manage/apply function, conditional _internals export,
+    and Vitest spec with describe/it/beforeEach.
 ---
+
+<!-- AUTO-GENERATED from .agents/skills/addon-scaffold/SKILL.md — do not edit. Edit the source, then run: npm run agents:sync -->
 
 # Addon Scaffold — Addon Generator
 
 ## Purpose
 
 Guide the user to create a new addon in two files:
-- `src/addons/tc-{name}.ts` — implementation
-- `src/addons/tc-{name}.spec.ts` — Vitest tests
+
+-   `src/addons/tc-{name}.ts` — implementation
+-   `src/addons/tc-{name}.spec.ts` — Vitest tests
 
 Enforce consistency by following established project patterns.
 
@@ -25,17 +28,19 @@ Enforce consistency by following established project patterns.
 **Ask**: "What is the addon name? (e.g., clipboard-history, syntax-highlight)"
 
 Automatically derive from the provided name:
-- **PascalCase** for the type (e.g., "clipboard-history" → `ClipboardHistory`)
-- **camelCase** for the function (e.g., `manageClipboardHistory`)
-- **kebab-case** for files (e.g., `tc-clipboard-history.ts`)
+
+-   **PascalCase** for the type (e.g., "clipboard-history" → `ClipboardHistory`)
+-   **camelCase** for the function (e.g., `manageClipboardHistory`)
+-   **kebab-case** for files (e.g., `tc-clipboard-history.ts`)
 
 ### 2. Request Addon Details
 
 **Ask**:
-- "Brief description of what this addon does?"
-- "Will the function be manage[Name] or apply[Name]?" (default: manage)
-- "Additional options beyond `active?: boolean`?" (If yes, list field names)
-- "Any dependencies or mocks needed?" (e.g., import from '../utils/helper')
+
+-   "Brief description of what this addon does?"
+-   "Will the function be manage[Name] or apply[Name]?" (default: manage)
+-   "Additional options beyond `active?: boolean`?" (If yes, list field names)
+-   "Any dependencies or mocks needed?" (e.g., import from '../utils/helper')
 
 ### 3. Generate TypeScript File
 
@@ -121,16 +126,17 @@ describe('{PascalName}', () => {
 
 ## Conventions (Mandatory)
 
-- **Interface**: Always named `Tc{PascalName}Options`, ALWAYS includes `active?: boolean` as first field
-- **Function**: Starts with `manage` or `apply` followed by PascalCase name
-- **Helper functions**: Prefix with `_`, accessible only via `_internals` in test mode
-- **_internals**: Conditional export returning helpers in test, `undefined` otherwise
-- **Spec file**: Must include `@vitest-environment jsdom` directive, use `describe/it/beforeEach` structure
-- **No over-abstraction**: Each addon is unique; don't force shared patterns prematurely
+-   **Interface**: Always named `Tc{PascalName}Options`, ALWAYS includes `active?: boolean` as first field
+-   **Function**: Starts with `manage` or `apply` followed by PascalCase name
+-   **Helper functions**: Prefix with `_`, accessible only via `_internals` in test mode
+-   **\_internals**: Conditional export returning helpers in test, `undefined` otherwise
+-   **Spec file**: Must include `@vitest-environment jsdom` directive, use `describe/it/beforeEach` structure
+-   **No over-abstraction**: Each addon is unique; don't force shared patterns prematurely
 
 ## Final Output
 
 Display:
+
 ```
 ✅ Created src/addons/tc-{kebab-name}.ts
 ✅ Created src/addons/tc-{kebab-name}.spec.ts

--- a/.gemini/skills/addon-scaffold/SKILL.md
+++ b/.gemini/skills/addon-scaffold/SKILL.md
@@ -1,0 +1,142 @@
+---
+name: addon-scaffold
+description: >
+  Generate a new addon for TalkControl following TypeScript + Vitest conventions.
+  Use when the user says "create an addon", "new addon", "add an addon", or wants to generate
+  src/addons/tc-{name}.ts and corresponding Vitest spec.
+  Follow existing patterns: TcXxxOptions interface, manage/apply function, conditional _internals export,
+  and Vitest spec with describe/it/beforeEach.
+---
+
+# Addon Scaffold — Addon Generator
+
+## Purpose
+
+Guide the user to create a new addon in two files:
+- `src/addons/tc-{name}.ts` — implementation
+- `src/addons/tc-{name}.spec.ts` — Vitest tests
+
+Enforce consistency by following established project patterns.
+
+## Conversational Workflow
+
+### 1. Request Addon Name
+
+**Ask**: "What is the addon name? (e.g., clipboard-history, syntax-highlight)"
+
+Automatically derive from the provided name:
+- **PascalCase** for the type (e.g., "clipboard-history" → `ClipboardHistory`)
+- **camelCase** for the function (e.g., `manageClipboardHistory`)
+- **kebab-case** for files (e.g., `tc-clipboard-history.ts`)
+
+### 2. Request Addon Details
+
+**Ask**:
+- "Brief description of what this addon does?"
+- "Will the function be manage[Name] or apply[Name]?" (default: manage)
+- "Additional options beyond `active?: boolean`?" (If yes, list field names)
+- "Any dependencies or mocks needed?" (e.g., import from '../utils/helper')
+
+### 3. Generate TypeScript File
+
+Create `src/addons/tc-{name}.ts` following this pattern:
+
+```typescript
+// Imports (adapt based on actual dependencies)
+export interface Tc{PascalName}Options {
+    active?: boolean;
+    // + additional fields if applicable
+}
+
+/**
+ * {Brief description from user}
+ * @param options configuration options
+ * @returns void
+ */
+export function {manage|apply}{PascalName}(options: Tc{PascalName}Options): void {
+    if (!options.active) {
+        return;
+    }
+
+    // TODO: Implement logic
+}
+
+// Private helper functions (optional)
+// function _helperName(...) { ... }
+
+// Export _internals (required pattern)
+export const _internals =
+    typeof process !== 'undefined' && process?.env?.NODE_ENV === 'test'
+        ? {
+              // Export testable helper functions here if applicable
+              // _helperName,
+          }
+        : undefined;
+```
+
+### 4. Generate Spec File
+
+Create `src/addons/tc-{name}.spec.ts` following this pattern:
+
+```typescript
+/**
+ * @vitest-environment jsdom
+ */
+import { {manage|apply}{PascalName}, Tc{PascalName}Options } from './tc-{kebab-name}';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const HTML = `
+<div class="reveal">
+    <div class="slides">
+        <!-- DOM fixture for tests -->
+    </div>
+</div>
+`;
+
+// vi.mock('../utils/helper', () => ({...})); // if needed
+
+describe('{PascalName}', () => {
+    beforeEach(() => {
+        document.body.innerHTML = HTML;
+    });
+
+    it('should export the function', () => {
+        expect({manage|apply}{PascalName}).toBeDefined();
+    });
+
+    it('should not do anything if options.active is false', () => {
+        const options: Tc{PascalName}Options = { active: false };
+        const result = {manage|apply}{PascalName}(options);
+        expect(result).toBeUndefined();
+    });
+
+    it('should work when options.active is true', () => {
+        const options: Tc{PascalName}Options = { active: true };
+        // TODO: Add meaningful test for actual logic
+        const result = {manage|apply}{PascalName}(options);
+        expect(result).toBeUndefined();
+    });
+});
+```
+
+## Conventions (Mandatory)
+
+- **Interface**: Always named `Tc{PascalName}Options`, ALWAYS includes `active?: boolean` as first field
+- **Function**: Starts with `manage` or `apply` followed by PascalCase name
+- **Helper functions**: Prefix with `_`, accessible only via `_internals` in test mode
+- **_internals**: Conditional export returning helpers in test, `undefined` otherwise
+- **Spec file**: Must include `@vitest-environment jsdom` directive, use `describe/it/beforeEach` structure
+- **No over-abstraction**: Each addon is unique; don't force shared patterns prematurely
+
+## Final Output
+
+Display:
+```
+✅ Created src/addons/tc-{kebab-name}.ts
+✅ Created src/addons/tc-{kebab-name}.spec.ts
+
+Next steps:
+  1. Implement logic in the .ts file
+  2. Add meaningful tests in the .spec.ts file
+  3. Run tests: npm run test -- {kebab-name}
+```

--- a/.gemini/skills/release/SKILL.md
+++ b/.gemini/skills/release/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: release
+description: >
+  Publish a new version of the npm package @talk-control/talk-control-revealjs-extensions.
+  Use when the user mentions "release", "publish", "npm publish", "new version", "bump version", or "tag".
+  Guides step by step: working tree check, bump type choice, build, tests, version bump, commit, tag, push, publish.
+---
+
+# Release — npm Publication
+
+## Overview
+
+The release workflow is automated via `npm run release` (calls `scripts/release.ts`).
+
+**Order of operations — build and tests run BEFORE bumping the version:**
+1. Check clean working tree
+2. Ask bump type (patch / minor / major)
+3. Build — stops here if it fails (package.json unchanged)
+4. Tests — stops here if they fail (package.json unchanged)
+5. Bump version in package.json
+6. git commit + git tag vX.Y.Z
+7. git push + git push --tags
+8. npm publish
+
+## Running the Release
+
+```bash
+npm run release
+```
+
+The script is interactive — it will ask for the bump type and show progress for each step.
+
+## Manual Step-by-Step (if the script fails mid-way)
+
+### 1. Check clean working tree
+```bash
+git status --porcelain
+```
+If output is non-empty, commit or stash changes first.
+
+### 2. Build
+```bash
+npm run build
+```
+
+### 3. Tests
+```bash
+npx vitest run
+```
+Note: use `npx vitest run` (single pass), NOT `npm run test` (watch mode).
+
+### 4. Bump version
+```bash
+npm version patch --no-git-tag-version
+# or: minor / major
+```
+`--no-git-tag-version` prevents npm from creating the git tag automatically.
+
+### 5. Commit + Tag
+```bash
+git add package.json package-lock.json
+git commit -m "chore: bump version to vX.Y.Z"
+git tag vX.Y.Z
+```
+
+### 6. Push
+```bash
+git push
+git push --tags
+```
+
+### 7. Publish
+```bash
+npm publish
+```
+`publishConfig.access: "public"` is already set in package.json — no `--access public` needed.
+
+## If a Step Fails After the Commit
+
+- Do NOT delete the git tag automatically
+- `npm publish` can be re-run independently if push succeeded but publish failed
+- Report what failed and suggest the exact command to resume

--- a/.gemini/skills/release/SKILL.md
+++ b/.gemini/skills/release/SKILL.md
@@ -1,10 +1,12 @@
 ---
 name: release
 description: >
-  Publish a new version of the npm package @talk-control/talk-control-revealjs-extensions.
-  Use when the user mentions "release", "publish", "npm publish", "new version", "bump version", or "tag".
-  Guides step by step: working tree check, bump type choice, build, tests, version bump, commit, tag, push, publish.
+    Publish a new version of the npm package @talk-control/talk-control-revealjs-extensions.
+    Use when the user mentions "release", "publish", "npm publish", "new version", "bump version", or "tag".
+    Guides step by step: working tree check, bump type choice, build, tests, version bump, commit, tag, push, publish.
 ---
+
+<!-- AUTO-GENERATED from .agents/skills/release/SKILL.md — do not edit. Edit the source, then run: npm run agents:sync -->
 
 # Release — npm Publication
 
@@ -13,6 +15,7 @@ description: >
 The release workflow is automated via `npm run release` (calls `scripts/release.ts`).
 
 **Order of operations — build and tests run BEFORE bumping the version:**
+
 1. Check clean working tree
 2. Ask bump type (patch / minor / major)
 3. Build — stops here if it fails (package.json unchanged)
@@ -33,30 +36,38 @@ The script is interactive — it will ask for the bump type and show progress fo
 ## Manual Step-by-Step (if the script fails mid-way)
 
 ### 1. Check clean working tree
+
 ```bash
 git status --porcelain
 ```
+
 If output is non-empty, commit or stash changes first.
 
 ### 2. Build
+
 ```bash
 npm run build
 ```
 
 ### 3. Tests
+
 ```bash
 npx vitest run
 ```
+
 Note: use `npx vitest run` (single pass), NOT `npm run test` (watch mode).
 
 ### 4. Bump version
+
 ```bash
 npm version patch --no-git-tag-version
 # or: minor / major
 ```
+
 `--no-git-tag-version` prevents npm from creating the git tag automatically.
 
 ### 5. Commit + Tag
+
 ```bash
 git add package.json package-lock.json
 git commit -m "chore: bump version to vX.Y.Z"
@@ -64,19 +75,22 @@ git tag vX.Y.Z
 ```
 
 ### 6. Push
+
 ```bash
 git push
 git push --tags
 ```
 
 ### 7. Publish
+
 ```bash
 npm publish
 ```
+
 `publishConfig.access: "public"` is already set in package.json — no `--access public` needed.
 
 ## If a Step Fails After the Commit
 
-- Do NOT delete the git tag automatically
-- `npm publish` can be re-run independently if push succeeded but publish failed
-- Report what failed and suggest the exact command to resume
+-   Do NOT delete the git tag automatically
+-   `npm publish` can be re-run independently if push succeeded but publish failed
+-   Report what failed and suggest the exact command to resume

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,6 +26,7 @@ jobs:
         run: |
           npm run lint
           npm run prettier
+          npm run agents:check
       - name: Unit Tests
         run: npm test
       # TODO: setup Playwright tests or remove this 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -25,6 +25,7 @@ jobs:
         run: |
           npm run lint
           npm run prettier
+          npm run agents:check
       - name: Unit Tests
         run: npm test
       # TODO: setup Playwright tests or remove this 

--- a/.hooks/post-file-change.sh
+++ b/.hooks/post-file-change.sh
@@ -1,32 +1,40 @@
 #!/bin/bash
-# Universal post-file-change hook
-# Works with: git hooks, file watchers, CI/CD, IDE tools
+# Shared post-file-change hook — single implementation for every agent tool.
+# Called by: .claude/settings.json, .agents/hooks.json, .gemini/settings.json,
+#            .opencode/plugin/auto-format.ts (see AGENTS.md → "AI tooling").
 # Usage: post-file-change.sh <filepath>
+#
+# Formats ONLY the changed file (never the whole repo) when it matches
+# src/**/*.{ts,scss}. Any other path is skipped silently.
 
-FILE_PATH="$1"
-PROJECT_ROOT="${PROJECT_ROOT:-.}"
+set -u
+
+FILE_PATH="${1:-}"
 
 if [ -z "$FILE_PATH" ]; then
-    echo "❌ FILE_PATH not provided"
+    echo "❌ post-file-change.sh: no file path provided"
     exit 1
 fi
 
-# Pattern match: only process .ts and .scss files in src/
-if [[ "$FILE_PATH" =~ ^src/.*\.(ts|scss)$ ]]; then
-    cd "$PROJECT_ROOT" || exit 1
-
-    echo "🔧 Formatting: $FILE_PATH"
-    npm run lint:fix 2>/dev/null || true
-    npm run prettier:fix 2>/dev/null || true
-
-    if [ $? -eq 0 ]; then
-        echo "✅ Formatted: $FILE_PATH"
-        exit 0
-    else
-        echo "⚠️  Formatting had issues"
-        exit 1
-    fi
+# Only process .ts and .scss files under src/ (absolute or relative path)
+if [[ ! "$FILE_PATH" =~ (^|/)src/.*\.(ts|scss)$ ]]; then
+    exit 0
 fi
 
-# File doesn't match pattern, skip silently
-exit 0
+if [ ! -f "$FILE_PATH" ]; then
+    exit 0
+fi
+
+echo "🔧 Formatting: $FILE_PATH"
+
+STATUS=0
+npx eslint --fix "$FILE_PATH" || STATUS=1
+npx prettier --write "$FILE_PATH" || STATUS=1
+
+if [ "$STATUS" -eq 0 ]; then
+    echo "✅ Formatted: $FILE_PATH"
+else
+    echo "⚠️  Formatting had issues on: $FILE_PATH"
+fi
+
+exit "$STATUS"

--- a/.hooks/post-file-change.sh
+++ b/.hooks/post-file-change.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# Universal post-file-change hook
+# Works with: git hooks, file watchers, CI/CD, IDE tools
+# Usage: post-file-change.sh <filepath>
+
+FILE_PATH="$1"
+PROJECT_ROOT="${PROJECT_ROOT:-.}"
+
+if [ -z "$FILE_PATH" ]; then
+    echo "❌ FILE_PATH not provided"
+    exit 1
+fi
+
+# Pattern match: only process .ts and .scss files in src/
+if [[ "$FILE_PATH" =~ ^src/.*\.(ts|scss)$ ]]; then
+    cd "$PROJECT_ROOT" || exit 1
+
+    echo "🔧 Formatting: $FILE_PATH"
+    npm run lint:fix 2>/dev/null || true
+    npm run prettier:fix 2>/dev/null || true
+
+    if [ $? -eq 0 ]; then
+        echo "✅ Formatted: $FILE_PATH"
+        exit 0
+    else
+        echo "⚠️  Formatting had issues"
+        exit 1
+    fi
+fi
+
+# File doesn't match pattern, skip silently
+exit 0

--- a/.opencode/command/addon-scaffold.md
+++ b/.opencode/command/addon-scaffold.md
@@ -1,20 +1,23 @@
 ---
 name: addon-scaffold
 description: >
-  Generate a new addon for TalkControl following TypeScript + Vitest conventions.
-  Use when the user says "create an addon", "new addon", "add an addon", or wants to generate
-  src/addons/tc-{name}.ts and corresponding Vitest spec.
-  Follow existing patterns: TcXxxOptions interface, manage/apply function, conditional _internals export,
-  and Vitest spec with describe/it/beforeEach.
+    Generate a new addon for TalkControl following TypeScript + Vitest conventions.
+    Use when the user says "create an addon", "new addon", "add an addon", or wants to generate
+    src/addons/tc-{name}.ts and corresponding Vitest spec.
+    Follow existing patterns: TcXxxOptions interface, manage/apply function, conditional _internals export,
+    and Vitest spec with describe/it/beforeEach.
 ---
+
+<!-- AUTO-GENERATED from .agents/skills/addon-scaffold/SKILL.md — do not edit. Edit the source, then run: npm run agents:sync -->
 
 # Addon Scaffold — Addon Generator
 
 ## Purpose
 
 Guide the user to create a new addon in two files:
-- `src/addons/tc-{name}.ts` — implementation
-- `src/addons/tc-{name}.spec.ts` — Vitest tests
+
+-   `src/addons/tc-{name}.ts` — implementation
+-   `src/addons/tc-{name}.spec.ts` — Vitest tests
 
 Enforce consistency by following established project patterns.
 
@@ -25,17 +28,19 @@ Enforce consistency by following established project patterns.
 **Ask**: "What is the addon name? (e.g., clipboard-history, syntax-highlight)"
 
 Automatically derive from the provided name:
-- **PascalCase** for the type (e.g., "clipboard-history" → `ClipboardHistory`)
-- **camelCase** for the function (e.g., `manageClipboardHistory`)
-- **kebab-case** for files (e.g., `tc-clipboard-history.ts`)
+
+-   **PascalCase** for the type (e.g., "clipboard-history" → `ClipboardHistory`)
+-   **camelCase** for the function (e.g., `manageClipboardHistory`)
+-   **kebab-case** for files (e.g., `tc-clipboard-history.ts`)
 
 ### 2. Request Addon Details
 
 **Ask**:
-- "Brief description of what this addon does?"
-- "Will the function be manage[Name] or apply[Name]?" (default: manage)
-- "Additional options beyond `active?: boolean`?" (If yes, list field names)
-- "Any dependencies or mocks needed?" (e.g., import from '../utils/helper')
+
+-   "Brief description of what this addon does?"
+-   "Will the function be manage[Name] or apply[Name]?" (default: manage)
+-   "Additional options beyond `active?: boolean`?" (If yes, list field names)
+-   "Any dependencies or mocks needed?" (e.g., import from '../utils/helper')
 
 ### 3. Generate TypeScript File
 
@@ -121,16 +126,17 @@ describe('{PascalName}', () => {
 
 ## Conventions (Mandatory)
 
-- **Interface**: Always named `Tc{PascalName}Options`, ALWAYS includes `active?: boolean` as first field
-- **Function**: Starts with `manage` or `apply` followed by PascalCase name
-- **Helper functions**: Prefix with `_`, accessible only via `_internals` in test mode
-- **_internals**: Conditional export returning helpers in test, `undefined` otherwise
-- **Spec file**: Must include `@vitest-environment jsdom` directive, use `describe/it/beforeEach` structure
-- **No over-abstraction**: Each addon is unique; don't force shared patterns prematurely
+-   **Interface**: Always named `Tc{PascalName}Options`, ALWAYS includes `active?: boolean` as first field
+-   **Function**: Starts with `manage` or `apply` followed by PascalCase name
+-   **Helper functions**: Prefix with `_`, accessible only via `_internals` in test mode
+-   **\_internals**: Conditional export returning helpers in test, `undefined` otherwise
+-   **Spec file**: Must include `@vitest-environment jsdom` directive, use `describe/it/beforeEach` structure
+-   **No over-abstraction**: Each addon is unique; don't force shared patterns prematurely
 
 ## Final Output
 
 Display:
+
 ```
 ✅ Created src/addons/tc-{kebab-name}.ts
 ✅ Created src/addons/tc-{kebab-name}.spec.ts

--- a/.opencode/command/addon-scaffold.md
+++ b/.opencode/command/addon-scaffold.md
@@ -1,0 +1,142 @@
+---
+name: addon-scaffold
+description: >
+  Generate a new addon for TalkControl following TypeScript + Vitest conventions.
+  Use when the user says "create an addon", "new addon", "add an addon", or wants to generate
+  src/addons/tc-{name}.ts and corresponding Vitest spec.
+  Follow existing patterns: TcXxxOptions interface, manage/apply function, conditional _internals export,
+  and Vitest spec with describe/it/beforeEach.
+---
+
+# Addon Scaffold — Addon Generator
+
+## Purpose
+
+Guide the user to create a new addon in two files:
+- `src/addons/tc-{name}.ts` — implementation
+- `src/addons/tc-{name}.spec.ts` — Vitest tests
+
+Enforce consistency by following established project patterns.
+
+## Conversational Workflow
+
+### 1. Request Addon Name
+
+**Ask**: "What is the addon name? (e.g., clipboard-history, syntax-highlight)"
+
+Automatically derive from the provided name:
+- **PascalCase** for the type (e.g., "clipboard-history" → `ClipboardHistory`)
+- **camelCase** for the function (e.g., `manageClipboardHistory`)
+- **kebab-case** for files (e.g., `tc-clipboard-history.ts`)
+
+### 2. Request Addon Details
+
+**Ask**:
+- "Brief description of what this addon does?"
+- "Will the function be manage[Name] or apply[Name]?" (default: manage)
+- "Additional options beyond `active?: boolean`?" (If yes, list field names)
+- "Any dependencies or mocks needed?" (e.g., import from '../utils/helper')
+
+### 3. Generate TypeScript File
+
+Create `src/addons/tc-{name}.ts` following this pattern:
+
+```typescript
+// Imports (adapt based on actual dependencies)
+export interface Tc{PascalName}Options {
+    active?: boolean;
+    // + additional fields if applicable
+}
+
+/**
+ * {Brief description from user}
+ * @param options configuration options
+ * @returns void
+ */
+export function {manage|apply}{PascalName}(options: Tc{PascalName}Options): void {
+    if (!options.active) {
+        return;
+    }
+
+    // TODO: Implement logic
+}
+
+// Private helper functions (optional)
+// function _helperName(...) { ... }
+
+// Export _internals (required pattern)
+export const _internals =
+    typeof process !== 'undefined' && process?.env?.NODE_ENV === 'test'
+        ? {
+              // Export testable helper functions here if applicable
+              // _helperName,
+          }
+        : undefined;
+```
+
+### 4. Generate Spec File
+
+Create `src/addons/tc-{name}.spec.ts` following this pattern:
+
+```typescript
+/**
+ * @vitest-environment jsdom
+ */
+import { {manage|apply}{PascalName}, Tc{PascalName}Options } from './tc-{kebab-name}';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const HTML = `
+<div class="reveal">
+    <div class="slides">
+        <!-- DOM fixture for tests -->
+    </div>
+</div>
+`;
+
+// vi.mock('../utils/helper', () => ({...})); // if needed
+
+describe('{PascalName}', () => {
+    beforeEach(() => {
+        document.body.innerHTML = HTML;
+    });
+
+    it('should export the function', () => {
+        expect({manage|apply}{PascalName}).toBeDefined();
+    });
+
+    it('should not do anything if options.active is false', () => {
+        const options: Tc{PascalName}Options = { active: false };
+        const result = {manage|apply}{PascalName}(options);
+        expect(result).toBeUndefined();
+    });
+
+    it('should work when options.active is true', () => {
+        const options: Tc{PascalName}Options = { active: true };
+        // TODO: Add meaningful test for actual logic
+        const result = {manage|apply}{PascalName}(options);
+        expect(result).toBeUndefined();
+    });
+});
+```
+
+## Conventions (Mandatory)
+
+- **Interface**: Always named `Tc{PascalName}Options`, ALWAYS includes `active?: boolean` as first field
+- **Function**: Starts with `manage` or `apply` followed by PascalCase name
+- **Helper functions**: Prefix with `_`, accessible only via `_internals` in test mode
+- **_internals**: Conditional export returning helpers in test, `undefined` otherwise
+- **Spec file**: Must include `@vitest-environment jsdom` directive, use `describe/it/beforeEach` structure
+- **No over-abstraction**: Each addon is unique; don't force shared patterns prematurely
+
+## Final Output
+
+Display:
+```
+✅ Created src/addons/tc-{kebab-name}.ts
+✅ Created src/addons/tc-{kebab-name}.spec.ts
+
+Next steps:
+  1. Implement logic in the .ts file
+  2. Add meaningful tests in the .spec.ts file
+  3. Run tests: npm run test -- {kebab-name}
+```

--- a/.opencode/command/release.md
+++ b/.opencode/command/release.md
@@ -1,0 +1,82 @@
+---
+name: release
+description: >
+  Publish a new version of the npm package @talk-control/talk-control-revealjs-extensions.
+  Use when the user mentions "release", "publish", "npm publish", "new version", "bump version", or "tag".
+  Guides step by step: working tree check, bump type choice, build, tests, version bump, commit, tag, push, publish.
+---
+
+# Release — npm Publication
+
+## Overview
+
+The release workflow is automated via `npm run release` (calls `scripts/release.ts`).
+
+**Order of operations — build and tests run BEFORE bumping the version:**
+1. Check clean working tree
+2. Ask bump type (patch / minor / major)
+3. Build — stops here if it fails (package.json unchanged)
+4. Tests — stops here if they fail (package.json unchanged)
+5. Bump version in package.json
+6. git commit + git tag vX.Y.Z
+7. git push + git push --tags
+8. npm publish
+
+## Running the Release
+
+```bash
+npm run release
+```
+
+The script is interactive — it will ask for the bump type and show progress for each step.
+
+## Manual Step-by-Step (if the script fails mid-way)
+
+### 1. Check clean working tree
+```bash
+git status --porcelain
+```
+If output is non-empty, commit or stash changes first.
+
+### 2. Build
+```bash
+npm run build
+```
+
+### 3. Tests
+```bash
+npx vitest run
+```
+Note: use `npx vitest run` (single pass), NOT `npm run test` (watch mode).
+
+### 4. Bump version
+```bash
+npm version patch --no-git-tag-version
+# or: minor / major
+```
+`--no-git-tag-version` prevents npm from creating the git tag automatically.
+
+### 5. Commit + Tag
+```bash
+git add package.json package-lock.json
+git commit -m "chore: bump version to vX.Y.Z"
+git tag vX.Y.Z
+```
+
+### 6. Push
+```bash
+git push
+git push --tags
+```
+
+### 7. Publish
+```bash
+npm publish
+```
+`publishConfig.access: "public"` is already set in package.json — no `--access public` needed.
+
+## If a Step Fails After the Commit
+
+- Do NOT delete the git tag automatically
+- `npm publish` can be re-run independently if push succeeded but publish failed
+- Report what failed and suggest the exact command to resume

--- a/.opencode/command/release.md
+++ b/.opencode/command/release.md
@@ -1,10 +1,12 @@
 ---
 name: release
 description: >
-  Publish a new version of the npm package @talk-control/talk-control-revealjs-extensions.
-  Use when the user mentions "release", "publish", "npm publish", "new version", "bump version", or "tag".
-  Guides step by step: working tree check, bump type choice, build, tests, version bump, commit, tag, push, publish.
+    Publish a new version of the npm package @talk-control/talk-control-revealjs-extensions.
+    Use when the user mentions "release", "publish", "npm publish", "new version", "bump version", or "tag".
+    Guides step by step: working tree check, bump type choice, build, tests, version bump, commit, tag, push, publish.
 ---
+
+<!-- AUTO-GENERATED from .agents/skills/release/SKILL.md — do not edit. Edit the source, then run: npm run agents:sync -->
 
 # Release — npm Publication
 
@@ -13,6 +15,7 @@ description: >
 The release workflow is automated via `npm run release` (calls `scripts/release.ts`).
 
 **Order of operations — build and tests run BEFORE bumping the version:**
+
 1. Check clean working tree
 2. Ask bump type (patch / minor / major)
 3. Build — stops here if it fails (package.json unchanged)
@@ -33,30 +36,38 @@ The script is interactive — it will ask for the bump type and show progress fo
 ## Manual Step-by-Step (if the script fails mid-way)
 
 ### 1. Check clean working tree
+
 ```bash
 git status --porcelain
 ```
+
 If output is non-empty, commit or stash changes first.
 
 ### 2. Build
+
 ```bash
 npm run build
 ```
 
 ### 3. Tests
+
 ```bash
 npx vitest run
 ```
+
 Note: use `npx vitest run` (single pass), NOT `npm run test` (watch mode).
 
 ### 4. Bump version
+
 ```bash
 npm version patch --no-git-tag-version
 # or: minor / major
 ```
+
 `--no-git-tag-version` prevents npm from creating the git tag automatically.
 
 ### 5. Commit + Tag
+
 ```bash
 git add package.json package-lock.json
 git commit -m "chore: bump version to vX.Y.Z"
@@ -64,19 +75,22 @@ git tag vX.Y.Z
 ```
 
 ### 6. Push
+
 ```bash
 git push
 git push --tags
 ```
 
 ### 7. Publish
+
 ```bash
 npm publish
 ```
+
 `publishConfig.access: "public"` is already set in package.json — no `--access public` needed.
 
 ## If a Step Fails After the Commit
 
-- Do NOT delete the git tag automatically
-- `npm publish` can be re-run independently if push succeeded but publish failed
-- Report what failed and suggest the exact command to resume
+-   Do NOT delete the git tag automatically
+-   `npm publish` can be re-run independently if push succeeded but publish failed
+-   Report what failed and suggest the exact command to resume

--- a/.opencode/plugin/auto-format.ts
+++ b/.opencode/plugin/auto-format.ts
@@ -1,14 +1,13 @@
-import type { Plugin } from "opencode-sdk";
+import type { Plugin } from 'opencode-sdk';
 
 export const AutoFormat: Plugin = async ({ $ }) => ({
     tool: {
         execute: {
             after: async (input, output) => {
-                if (input.tool === "edit") {
-                    const filePath: string = output.args?.filePath ?? "";
-                    if (/\/src\/.*\.(ts|scss)$/.test(filePath)) {
-                        await $`npm run lint:fix`;
-                        await $`npm run prettier:fix`;
+                if (input.tool === 'edit') {
+                    const filePath: string = output.args?.filePath ?? '';
+                    if (filePath) {
+                        await $`./.hooks/post-file-change.sh ${filePath}`;
                     }
                 }
             },

--- a/.opencode/plugin/auto-format.ts
+++ b/.opencode/plugin/auto-format.ts
@@ -1,0 +1,17 @@
+import type { Plugin } from "opencode-sdk";
+
+export const AutoFormat: Plugin = async ({ $ }) => ({
+    tool: {
+        execute: {
+            after: async (input, output) => {
+                if (input.tool === "edit") {
+                    const filePath: string = output.args?.filePath ?? "";
+                    if (/\/src\/.*\.(ts|scss)$/.test(filePath)) {
+                        await $`npm run lint:fix`;
+                        await $`npm run prettier:fix`;
+                    }
+                }
+            },
+        },
+    },
+});

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,150 @@
+# AGENTS.md
+
+Agent guidance for the `talk-control-revealjs-extensions` repository.
+
+## Project purpose
+
+**TalkControl** is an open-source npm library (`@talk-control/talk-control-revealjs-extensions`) that extends [reveal.js](https://revealjs.com) with a full theming, i18n, and Markdown enrichment system. It targets anyone who wants to build professional slide decks with reveal.js without wiring up plugins manually.
+
+The library ships:
+- A reveal.js plugin pair (markdown + theme)
+- A set of custom `marked` extensions (admonitions, icons, QR codes, column layouts, backgrounds)
+- LitHTML web components for the presentation shell and the live config panel
+- A SCSS theme (compiled to `dist/talk-control-revealjs-theme.css`)
+- Pre-bundled icon packs (Feather Icons, Font Awesome, Material Symbols)
+
+Live demo: <https://talk-control-revealjs-extensions.netlify.app/>
+
+## Tech stack & key versions
+
+| Technology | Version | Role |
+|---|---|---|
+| Node.js | 20 (see `.nvmrc`) | Runtime |
+| TypeScript | ^5.2 | Language — `ES2020` target, strict mode |
+| Vite | ^5.3 | Library bundler (ESM + UMD + `.d.ts` rollup via `vite-plugin-dts`) |
+| Vitest | ^1.6 | Unit testing |
+| reveal.js | ^5.1 | Presentation engine (peer dep + re-exported) |
+| marked | ^5.0 | Markdown parser (peer dep) |
+| LitHTML | ^3.1 | Web components for the UI shell |
+| Sass | ^1.77 | SCSS compilation |
+| ESLint | ^9.6 | Linting |
+| Prettier | ^3.3 | Formatting |
+
+Output format: dual ESM (`dist/talk-control-revealjs-extensions.js`) + UMD (`.umd.cjs`) + type declarations (`.d.ts`).
+
+## Commands
+
+```bash
+npm install          # Install dependencies
+npm run start        # Dev server at localhost:4242 (builds on src change, live-reloads demo)
+npm run build        # tsc + vite build → dist/ (postbuild copies to demo/)
+npm run test         # Vitest (watch mode)
+npm run lint         # ESLint
+npm run lint:fix     # ESLint with auto-fix
+npm run prettier     # Check formatting
+npm run prettier:fix # Fix formatting
+```
+
+Run a single test file: `npx vitest run src/addons/tc-copy-clipboard.spec.ts`
+
+CI runs `lint` → `prettier` → `test` on every push to `main`.
+
+## Architecture
+
+This is a **library** (not an app). The build output is `dist/`; the `demo/` folder is a static reveal.js presentation used exclusively for manual testing during development.
+
+### Consumer entry point
+
+`ThemeInitializer.init()` (`src/theme-initializer.ts`) is the single function consumers call:
+1. Reads `showType`, `lang`, `theme` from URL params / HTML `data-*` attributes
+2. Renders slide `<section>` elements into the DOM using LitHTML (or a custom `slidesRenderer`)
+3. Registers `RevealTalkControlMarkdownPlugin` — wraps `RevealMarkdown`, injects all `marked` extensions
+4. Registers `RevealTalkControlThemePlugin` — runs DOM transforms on the `ready` event
+5. Calls `Reveal.initialize()`
+
+Public API is re-exported from `src/index.ts`.
+
+### Plugin split
+
+| File | Plugin id | Responsibility |
+|---|---|---|
+| `src/theme-initializer.ts` | — | Orchestration, LitHTML rendering, Reveal init |
+| `src/marked/tc-marked-plugin.ts` | `talk-control-markdown` | Wraps `RevealMarkdown`; registers marked extensions post-init (init resets the renderer) |
+| `src/theme-plugin.ts` | `talk-control-theme` | `Reveal ready` hook: backgrounds, columns, copy-clipboard, data-type |
+
+### Addons (`src/addons/`)
+
+Each addon is a standalone module with its own `.spec.ts`:
+
+| Addon | What it does |
+|---|---|
+| `tc-copy-clipboard` | Adds a copy button to code blocks |
+| `tc-custom-background` | Maps CSS class names on `<section>` to CSS background values |
+| `tc-data-type` | Manages `data-type` (show type: `on-stage`, `training`, …) |
+| `tc-theme` | Manages `data-theme` attribute |
+| `tc-i18n` | Manages `data-lang` and Markdown file path resolution |
+| `tc-multiples-cols` | Post-processes column layout HTML |
+| `tc-ui-config` | Config panel opened with the `C` key |
+| `tc-list-fragment` | Transforms list items into reveal fragments |
+
+### Marked extensions (`src/marked/`)
+
+Custom `marked` extensions that parse non-standard Markdown into reveal-compatible HTML:
+
+| Extension | Syntax |
+|---|---|
+| `marked-tc-admonition` | `:::note`, `:::warning` blocks |
+| `marked-tc-bg` | `<!-- bg:… -->` comments for slide backgrounds |
+| `marked-tc-cols` | Column layout syntax |
+| `marked-tc-icons` | Icon shorthand (e.g. `::icon-name::`) |
+| `marked-tc-qrcode` | QR code generation |
+
+### UI components (`src/ui/`)
+
+LitHTML web components:
+
+| Component | Role |
+|---|---|
+| `tc-talk-control-element` | Main wrapper element |
+| `tc-revealjs-element` | reveal.js container |
+| `tc-configurator-element` | Config panel (`C` key) |
+| `tc-tree-slides-element` | Slide navigator |
+
+### Icon packs (`src/icons-config/`)
+
+`feather-icons-pack`, `font-awesome-pack`, `material-symbols-pack` each export a `MarkedTcIconsOptions` object ready to pass as `tcMarkedOptions.fontIcons[n]`.
+
+### SCSS (`src/scss/theme/`)
+
+SCSS theme variables and component styles. `src/index.scss` imports reveal.js base CSS, a highlight.js theme, and the TalkControl SCSS tree. The compiled output is `dist/talk-control-revealjs-theme.css`.
+
+### Demo loop (`demo/`)
+
+`scripts/prepare-demo.ts` copies `dist/` into `demo/web_modules/`. `npm run start` chains three parallel processes: `_on-change:build` (rebuild on `src/` change) → `_on-change:copy` (copy `dist/` to `demo/` on change) → `_serve` (live-server on port 4242).
+
+## Conventions
+
+### Commit messages
+
+Conventional commits, in English, no Gitmoji:
+
+```
+feat | fix | docs | style | refactor | perf | test | chore | ci | build | revert | BREAKING CHANGE | WIP
+```
+
+### Tests
+
+Vitest. Use `describe`/`it`, `beforeEach`/`afterEach`, `expect`. Mock with `vi.fn()`, `vi.spyOn()`, `vi.mock()`, `vi.clearAllMocks()` — only when necessary.
+
+Functions exposed only for tests are exported under a `_internals` guard:
+
+```ts
+export const _internals =
+    typeof process !== 'undefined' && process?.env?.NODE_ENV === 'test'
+        ? { _myPrivateFunction }
+        : undefined;
+```
+
+### TypeScript
+
+Strict mode. `ES2020` target. `experimentalDecorators` enabled (required by LitHTML). `noUnusedLocals` and `noUnusedParameters` enforced.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,28 +7,29 @@ Agent guidance for the `talk-control-revealjs-extensions` repository.
 **TalkControl** is an open-source npm library (`@talk-control/talk-control-revealjs-extensions`) that extends [reveal.js](https://revealjs.com) with a full theming, i18n, and Markdown enrichment system. It targets anyone who wants to build professional slide decks with reveal.js without wiring up plugins manually.
 
 The library ships:
-- A reveal.js plugin pair (markdown + theme)
-- A set of custom `marked` extensions (admonitions, icons, QR codes, column layouts, backgrounds)
-- LitHTML web components for the presentation shell and the live config panel
-- A SCSS theme (compiled to `dist/talk-control-revealjs-theme.css`)
-- Pre-bundled icon packs (Feather Icons, Font Awesome, Material Symbols)
+
+-   A reveal.js plugin pair (markdown + theme)
+-   A set of custom `marked` extensions (admonitions, icons, QR codes, column layouts, backgrounds)
+-   LitHTML web components for the presentation shell and the live config panel
+-   A SCSS theme (compiled to `dist/talk-control-revealjs-theme.css`)
+-   Pre-bundled icon packs (Feather Icons, Font Awesome, Material Symbols)
 
 Live demo: <https://talk-control-revealjs-extensions.netlify.app/>
 
 ## Tech stack & key versions
 
-| Technology | Version | Role |
-|---|---|---|
-| Node.js | 20 (see `.nvmrc`) | Runtime |
-| TypeScript | ^5.2 | Language — `ES2020` target, strict mode |
-| Vite | ^5.3 | Library bundler (ESM + UMD + `.d.ts` rollup via `vite-plugin-dts`) |
-| Vitest | ^1.6 | Unit testing |
-| reveal.js | ^5.1 | Presentation engine (peer dep + re-exported) |
-| marked | ^5.0 | Markdown parser (peer dep) |
-| LitHTML | ^3.1 | Web components for the UI shell |
-| Sass | ^1.77 | SCSS compilation |
-| ESLint | ^9.6 | Linting |
-| Prettier | ^3.3 | Formatting |
+| Technology | Version           | Role                                                               |
+| ---------- | ----------------- | ------------------------------------------------------------------ |
+| Node.js    | 20 (see `.nvmrc`) | Runtime                                                            |
+| TypeScript | ^5.2              | Language — `ES2020` target, strict mode                            |
+| Vite       | ^5.3              | Library bundler (ESM + UMD + `.d.ts` rollup via `vite-plugin-dts`) |
+| Vitest     | ^1.6              | Unit testing                                                       |
+| reveal.js  | ^5.1              | Presentation engine (peer dep + re-exported)                       |
+| marked     | ^5.0              | Markdown parser (peer dep)                                         |
+| LitHTML    | ^3.1              | Web components for the UI shell                                    |
+| Sass       | ^1.77             | SCSS compilation                                                   |
+| ESLint     | ^9.6              | Linting                                                            |
+| Prettier   | ^3.3              | Formatting                                                         |
 
 Output format: dual ESM (`dist/talk-control-revealjs-extensions.js`) + UMD (`.umd.cjs`) + type declarations (`.d.ts`).
 
@@ -47,7 +48,7 @@ npm run prettier:fix # Fix formatting
 
 Run a single test file: `npx vitest run src/addons/tc-copy-clipboard.spec.ts`
 
-CI runs `lint` → `prettier` → `test` on every push to `main`.
+CI runs `lint` → `prettier` → `agents:check` → `test` on every push to `main` and every PR.
 
 ## Architecture
 
@@ -56,6 +57,7 @@ This is a **library** (not an app). The build output is `dist/`; the `demo/` fol
 ### Consumer entry point
 
 `ThemeInitializer.init()` (`src/theme-initializer.ts`) is the single function consumers call:
+
 1. Reads `showType`, `lang`, `theme` from URL params / HTML `data-*` attributes
 2. Renders slide `<section>` elements into the DOM using LitHTML (or a custom `slidesRenderer`)
 3. Registers `RevealTalkControlMarkdownPlugin` — wraps `RevealMarkdown`, injects all `marked` extensions
@@ -66,49 +68,49 @@ Public API is re-exported from `src/index.ts`.
 
 ### Plugin split
 
-| File | Plugin id | Responsibility |
-|---|---|---|
-| `src/theme-initializer.ts` | — | Orchestration, LitHTML rendering, Reveal init |
+| File                             | Plugin id               | Responsibility                                                                           |
+| -------------------------------- | ----------------------- | ---------------------------------------------------------------------------------------- |
+| `src/theme-initializer.ts`       | —                       | Orchestration, LitHTML rendering, Reveal init                                            |
 | `src/marked/tc-marked-plugin.ts` | `talk-control-markdown` | Wraps `RevealMarkdown`; registers marked extensions post-init (init resets the renderer) |
-| `src/theme-plugin.ts` | `talk-control-theme` | `Reveal ready` hook: backgrounds, columns, copy-clipboard, data-type |
+| `src/theme-plugin.ts`            | `talk-control-theme`    | `Reveal ready` hook: backgrounds, columns, copy-clipboard, data-type                     |
 
 ### Addons (`src/addons/`)
 
 Each addon is a standalone module with its own `.spec.ts`:
 
-| Addon | What it does |
-|---|---|
-| `tc-copy-clipboard` | Adds a copy button to code blocks |
+| Addon                  | What it does                                                 |
+| ---------------------- | ------------------------------------------------------------ |
+| `tc-copy-clipboard`    | Adds a copy button to code blocks                            |
 | `tc-custom-background` | Maps CSS class names on `<section>` to CSS background values |
-| `tc-data-type` | Manages `data-type` (show type: `on-stage`, `training`, …) |
-| `tc-theme` | Manages `data-theme` attribute |
-| `tc-i18n` | Manages `data-lang` and Markdown file path resolution |
-| `tc-multiples-cols` | Post-processes column layout HTML |
-| `tc-ui-config` | Config panel opened with the `C` key |
-| `tc-list-fragment` | Transforms list items into reveal fragments |
+| `tc-data-type`         | Manages `data-type` (show type: `on-stage`, `training`, …)   |
+| `tc-theme`             | Manages `data-theme` attribute                               |
+| `tc-i18n`              | Manages `data-lang` and Markdown file path resolution        |
+| `tc-multiples-cols`    | Post-processes column layout HTML                            |
+| `tc-ui-config`         | Config panel opened with the `C` key                         |
+| `tc-list-fragment`     | Transforms list items into reveal fragments                  |
 
 ### Marked extensions (`src/marked/`)
 
 Custom `marked` extensions that parse non-standard Markdown into reveal-compatible HTML:
 
-| Extension | Syntax |
-|---|---|
-| `marked-tc-admonition` | `:::note`, `:::warning` blocks |
-| `marked-tc-bg` | `<!-- bg:… -->` comments for slide backgrounds |
-| `marked-tc-cols` | Column layout syntax |
-| `marked-tc-icons` | Icon shorthand (e.g. `::icon-name::`) |
-| `marked-tc-qrcode` | QR code generation |
+| Extension              | Syntax                                         |
+| ---------------------- | ---------------------------------------------- |
+| `marked-tc-admonition` | `:::note`, `:::warning` blocks                 |
+| `marked-tc-bg`         | `<!-- bg:… -->` comments for slide backgrounds |
+| `marked-tc-cols`       | Column layout syntax                           |
+| `marked-tc-icons`      | Icon shorthand (e.g. `::icon-name::`)          |
+| `marked-tc-qrcode`     | QR code generation                             |
 
 ### UI components (`src/ui/`)
 
 LitHTML web components:
 
-| Component | Role |
-|---|---|
-| `tc-talk-control-element` | Main wrapper element |
-| `tc-revealjs-element` | reveal.js container |
+| Component                 | Role                   |
+| ------------------------- | ---------------------- |
+| `tc-talk-control-element` | Main wrapper element   |
+| `tc-revealjs-element`     | reveal.js container    |
 | `tc-configurator-element` | Config panel (`C` key) |
-| `tc-tree-slides-element` | Slide navigator |
+| `tc-tree-slides-element`  | Slide navigator        |
 
 ### Icon packs (`src/icons-config/`)
 
@@ -148,3 +150,22 @@ export const _internals =
 ### TypeScript
 
 Strict mode. `ES2020` target. `experimentalDecorators` enabled (required by LitHTML). `noUnusedLocals` and `noUnusedParameters` enforced.
+
+## AI tooling
+
+This repo ships configuration for several agent tools (Claude Code, Gemini CLI, opencode, `.agents/`-compatible tools). Two rules keep it maintainable:
+
+### Skills — single source of truth
+
+`.agents/skills/` is the **canonical source** for agent skills. The copies under `.claude/skills/`, `.gemini/skills/` and `.opencode/command/` are **generated** (they carry an `AUTO-GENERATED` banner) — never edit them directly.
+
+```bash
+npm run agents:sync   # regenerate tool-specific copies from .agents/
+npm run agents:check  # verify copies are in sync (runs in CI, fails on drift)
+```
+
+To change a skill: edit the file under `.agents/skills/`, run `npm run agents:sync`, commit source + generated copies together. The manifest lives in `scripts/sync-agents.ts`.
+
+### Post-edit formatting hook — single implementation
+
+`.hooks/post-file-change.sh` is the shared formatter: it lints and formats **only the changed file** when it matches `src/**/*.{ts,scss}`. Every tool-specific hook config (`.claude/settings.json`, `.agents/hooks.json`, `.gemini/settings.json`, `.opencode/plugin/auto-format.ts`) is a thin adapter that extracts the file path and calls this script. Change formatting behavior in the script, not in the adapters.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+@AGENTS.md

--- a/package.json
+++ b/package.json
@@ -55,6 +55,8 @@
         "prettier": "prettier . --check",
         "prettier:fix": "prettier . --write",
         "release": "tsx scripts/release.ts",
+        "agents:sync": "tsx scripts/sync-agents.ts",
+        "agents:check": "tsx scripts/sync-agents.ts --check",
         "test": "vitest",
         "_on-change:build": "chokidar \"./src\" -c \"npm run build\"",
         "_on-change:copy": "chokidar \"./dist\" -c \"npm run _prepare-demo\"",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
         "lint:fix": "eslint --fix",
         "prettier": "prettier . --check",
         "prettier:fix": "prettier . --write",
+        "release": "tsx scripts/release.ts",
         "test": "vitest",
         "_on-change:build": "chokidar \"./src\" -c \"npm run build\"",
         "_on-change:copy": "chokidar \"./dist\" -c \"npm run _prepare-demo\"",

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -1,0 +1,99 @@
+#!/usr/bin/env node
+import { execSync } from 'child_process';
+import * as fs from 'fs';
+import * as readline from 'readline';
+
+interface PackageJson {
+    version: string;
+}
+
+async function askQuestion(question: string): Promise<string> {
+    const rl = readline.createInterface({
+        input: process.stdin,
+        output: process.stdout,
+    });
+    return new Promise(resolve => {
+        rl.question(question, answer => {
+            rl.close();
+            resolve(answer.trim());
+        });
+    });
+}
+
+async function release() {
+    try {
+        console.log('📦 Release\n');
+
+        // Step 1: Check clean working tree
+        console.log('1️⃣  Checking working tree...');
+        const status = execSync('git status --porcelain', { encoding: 'utf8' });
+        if (status.trim()) {
+            console.error('❌ Working tree is dirty. Commit or stash changes first.');
+            process.exit(1);
+        }
+        console.log('✅ Working tree is clean\n');
+
+        // Read current version for display
+        const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8')) as PackageJson;
+        console.log(`Current version: ${pkg.version}`);
+
+        // Step 2: Ask for bump type
+        const bumpType = await askQuestion(
+            '2️⃣  Bump type (patch/minor/major)? [patch] '
+        );
+        const bump = (bumpType || 'patch') as 'patch' | 'minor' | 'major';
+        console.log();
+
+        // Step 3: Build (BEFORE version bump)
+        console.log('3️⃣  Building...');
+        execSync('npm run build', { stdio: 'inherit' });
+        console.log('✅ Build successful\n');
+
+        // Step 4: Test (BEFORE version bump)
+        console.log('4️⃣  Running tests...');
+        execSync('npx vitest run', { stdio: 'inherit' });
+        console.log('✅ Tests passed\n');
+
+        // Step 5: Update version (ONLY if build + tests pass)
+        console.log('5️⃣  Bumping version...');
+        execSync(`npm version ${bump} --no-git-tag-version`, {
+            stdio: 'inherit',
+        });
+        const newPkg = JSON.parse(
+            fs.readFileSync('package.json', 'utf8')
+        ) as PackageJson;
+        const newVersion = newPkg.version;
+        console.log(`✅ Version bumped to ${newVersion}\n`);
+
+        // Step 6: Commit + Tag
+        console.log('6️⃣  Committing and tagging...');
+        execSync('git add package.json package-lock.json', {
+            stdio: 'inherit',
+        });
+        execSync(
+            `git commit -m "chore: bump version to v${newVersion}\n\nCo-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>"`,
+            { stdio: 'inherit' }
+        );
+        execSync(`git tag v${newVersion}`, { stdio: 'inherit' });
+        console.log(`✅ Commit & tag created (v${newVersion})\n`);
+
+        // Step 7: Push
+        console.log('7️⃣  Pushing to remote...');
+        execSync('git push', { stdio: 'inherit' });
+        execSync('git push --tags', { stdio: 'inherit' });
+        console.log('✅ Pushed to remote\n');
+
+        // Step 8: Publish
+        console.log('8️⃣  Publishing to npm...');
+        execSync('npm publish', { stdio: 'inherit' });
+        console.log(`✅ Published v${newVersion}\n`);
+
+        console.log('🎉 Release complete!');
+    } catch (error) {
+        console.error('\n❌ Release failed:', (error as Error).message);
+        console.error('⚠️  package.json was NOT modified\n');
+        process.exit(1);
+    }
+}
+
+release();

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
-import { execSync } from 'child_process';
 import * as fs from 'fs';
 import * as readline from 'readline';
+import { execSync } from 'child_process';
 
 interface PackageJson {
     version: string;
@@ -12,8 +12,8 @@ async function askQuestion(question: string): Promise<string> {
         input: process.stdin,
         output: process.stdout,
     });
-    return new Promise(resolve => {
-        rl.question(question, answer => {
+    return new Promise((resolve) => {
+        rl.question(question, (answer) => {
             rl.close();
             resolve(answer.trim());
         });
@@ -28,13 +28,17 @@ async function release() {
         console.log('1️⃣  Checking working tree...');
         const status = execSync('git status --porcelain', { encoding: 'utf8' });
         if (status.trim()) {
-            console.error('❌ Working tree is dirty. Commit or stash changes first.');
+            console.error(
+                '❌ Working tree is dirty. Commit or stash changes first.'
+            );
             process.exit(1);
         }
         console.log('✅ Working tree is clean\n');
 
         // Read current version for display
-        const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8')) as PackageJson;
+        const pkg = JSON.parse(
+            fs.readFileSync('package.json', 'utf8')
+        ) as PackageJson;
         console.log(`Current version: ${pkg.version}`);
 
         // Step 2: Ask for bump type
@@ -70,10 +74,9 @@ async function release() {
         execSync('git add package.json package-lock.json', {
             stdio: 'inherit',
         });
-        execSync(
-            `git commit -m "chore: bump version to v${newVersion}\n\nCo-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>"`,
-            { stdio: 'inherit' }
-        );
+        execSync(`git commit -m "chore: bump version to v${newVersion}"`, {
+            stdio: 'inherit',
+        });
         execSync(`git tag v${newVersion}`, { stdio: 'inherit' });
         console.log(`✅ Commit & tag created (v${newVersion})\n`);
 

--- a/scripts/sync-agents.ts
+++ b/scripts/sync-agents.ts
@@ -1,0 +1,109 @@
+#!/usr/bin/env node
+/**
+ * Sync agent skills from the canonical source (.agents/) to the
+ * tool-specific directories (.claude/, .gemini/, .opencode/).
+ *
+ * Usage:
+ *   npm run agents:sync    # regenerate all tool-specific copies
+ *   npm run agents:check   # verify copies are in sync (CI) — exit 1 on drift
+ *
+ * Never edit the generated copies directly: edit the source under
+ * .agents/, then run `npm run agents:sync`.
+ */
+import * as fs from 'fs';
+import * as path from 'path';
+
+interface SyncEntry {
+    source: string;
+    targets: string[];
+    /** Optional per-target transform (tool-specific format tweaks). */
+    transform?: (content: string, target: string) => string;
+}
+
+const MANIFEST: SyncEntry[] = [
+    {
+        source: '.agents/skills/release/SKILL.md',
+        targets: [
+            '.claude/skills/release/SKILL.md',
+            '.gemini/skills/release/SKILL.md',
+            '.opencode/command/release.md',
+        ],
+    },
+    {
+        source: '.agents/skills/addon-scaffold/SKILL.md',
+        targets: [
+            '.claude/skills/addon-scaffold/SKILL.md',
+            '.gemini/skills/addon-scaffold/SKILL.md',
+            '.opencode/command/addon-scaffold.md',
+        ],
+    },
+];
+
+function banner(source: string): string {
+    return `<!-- AUTO-GENERATED from ${source} — do not edit. Edit the source, then run: npm run agents:sync -->`;
+}
+
+/**
+ * Inject the auto-generated banner. YAML frontmatter must stay first,
+ * so the banner goes right after the closing `---` when present.
+ */
+function withBanner(content: string, source: string): string {
+    const frontmatterMatch = content.match(/^---\n[\s\S]*?\n---\n/);
+    if (frontmatterMatch) {
+        const frontmatter = frontmatterMatch[0];
+        const body = content.slice(frontmatter.length);
+        return `${frontmatter}\n${banner(source)}\n${body.replace(/^\n+/, '\n')}`;
+    }
+    return `${banner(source)}\n\n${content}`;
+}
+
+function expectedContent(entry: SyncEntry, target: string): string {
+    const raw = fs.readFileSync(entry.source, 'utf8');
+    const generated = withBanner(raw, entry.source);
+    return entry.transform ? entry.transform(generated, target) : generated;
+}
+
+function sync(): void {
+    for (const entry of MANIFEST) {
+        for (const target of entry.targets) {
+            const content = expectedContent(entry, target);
+            fs.mkdirSync(path.dirname(target), { recursive: true });
+            fs.writeFileSync(target, content);
+            console.log(`✅ ${entry.source} → ${target}`);
+        }
+    }
+    console.log('\n🎉 Agent skills synced');
+}
+
+function check(): void {
+    const drifted: string[] = [];
+    for (const entry of MANIFEST) {
+        for (const target of entry.targets) {
+            const expected = expectedContent(entry, target);
+            const actual = fs.existsSync(target)
+                ? fs.readFileSync(target, 'utf8')
+                : null;
+            if (actual !== expected) {
+                drifted.push(
+                    `  - ${target} (${actual === null ? 'missing' : 'differs from'} source ${entry.source})`
+                );
+            }
+        }
+    }
+    if (drifted.length > 0) {
+        console.error('❌ Agent skills are out of sync:\n');
+        console.error(drifted.join('\n'));
+        console.error(
+            '\nEdit the source under .agents/ (never the generated copies),'
+        );
+        console.error('then run: npm run agents:sync\n');
+        process.exit(1);
+    }
+    console.log('✅ Agent skills are in sync');
+}
+
+if (process.argv.includes('--check')) {
+    check();
+} else {
+    sync();
+}


### PR DESCRIPTION
## Summary

- Add PostToolUse lint+prettier hooks for Claude Code, Gemini CLI, Antigravity, and OpenCode — auto-formats `.ts`/`.scss` files in `src/` after every edit
- Add universal `scripts/release.ts` CLI (build + tests run **before** version bump) + `npm run release` script
- Add `addon-scaffold` and `release` skills for all 4 AI tools (same SKILL.md format, tool-specific directories)
- Add universal `.hooks/post-file-change.sh` shell hook callable from any tool or git hook

## Structure

```
.claude/skills/       ← Claude Code
.gemini/skills/       ← Gemini CLI
.agents/skills/       ← Antigravity
.opencode/command/    ← OpenCode
scripts/release.ts    ← Universal CLI
.hooks/               ← Universal shell hooks
```

## Test plan

- [ ] Trigger an edit on `src/` file with Claude Code → lint+prettier runs automatically
- [ ] Run `npm run release` → interactive CLI guides through the release flow
- [ ] Invoke `/addon-scaffold` skill → guided addon creation with correct TypeScript patterns
- [ ] Verify `.gemini/`, `.agents/`, `.opencode/` directories load skills correctly in each tool

🤖 Generated with [Claude Code](https://claude.com/claude-code)